### PR TITLE
Make -version=LIBEV4 default

### DIFF
--- a/deimos/ev.d
+++ b/deimos/ev.d
@@ -49,9 +49,10 @@ extern(C):
 //TODO: Better way to define default versions
 //TODO: EV_FEATURES_* is not working
 
+version = LIBEV4; // default
+
 /* pre-4.0 compatibility */
-/*version = LIBEV4;
-  version = LIBEV3_COMPAT;*/
+/* version = LIBEV3_COMPAT;*/
 version = EV_MULTIPLICITY;
 version = EV_PERIODIC_ENABLE;
 version = EV_STAT_ENABLE;


### PR DESCRIPTION
As LIBEV4 and LIBEV3_COMPAT are not exclusive, this should not cause any harm (at least that is what brief code examination shows). Will allow to import & use this bindings without mysterious error messages if no versions are specified.
