### PR TITLE
added "sourcePaths" : ["./deimos"]  so dub/compiler can find these files...

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,6 @@
 	"importPaths": ["."],
 	"targetType": "sourceLibrary",
 	"versions": ["LIBEV4"],
-	"libs-posix" : ["ev"]
+	"libs-posix" : ["ev"],
+	"sourcePaths" : ["./deimos"]
 }


### PR DESCRIPTION
- added "sourcePaths" : ["./deimos"]  so dub/compiler can find these files when building as a sourceLibrary.

getting undefined reference when using this library, dub is not adding deimos path to build, thus this wont build as a source library.
